### PR TITLE
allow wfs200 BB to be nil

### DIFF
--- a/pkg/wfs200/capabilities.go
+++ b/pkg/wfs200/capabilities.go
@@ -114,7 +114,7 @@ type FeatureType struct {
 	OutputFormats struct {
 		Format []string `xml:"wfs:Format" yaml:"format"`
 	} `xml:"wfs:OutputFormats" yaml:"outputformats"`
-	WGS84BoundingBox wsc110.WGS84BoundingBox `xml:"ows:WGS84BoundingBox" yaml:"wgs84boundingbox"`
+	WGS84BoundingBox *wsc110.WGS84BoundingBox `xml:"ows:WGS84BoundingBox" yaml:"wgs84boundingbox"`
 	MetadataURL      struct {
 		Href string `xml:"xlink:href,attr" yaml:"href"`
 	} `xml:"wfs:MetadataURL" yaml:"metadataurl"`


### PR DESCRIPTION
Merging base BB configuration fails on wfs capabilties generation and results in an bb of 0,0,0,0