### PR TITLE
Raise exception on invalid transparent value

### DIFF
--- a/pkg/wms130/getmap_request_pv.go
+++ b/pkg/wms130/getmap_request_pv.go
@@ -108,9 +108,11 @@ func (mpv *getMapRequestParameterValue) buildOutput() (Output, Exceptions) {
 
 	output.Size = Size{Height: h, Width: w}
 	output.Format = mpv.format
-	if b, err := strconv.ParseBool(*mpv.transparent); err == nil {
-		output.Transparent = &b
+	b, err := strconv.ParseBool(*mpv.transparent);
+	if err != nil {
+		return output, InvalidParameterValue(*mpv.transparent, TRANSPARENT).ToExceptions()
 	}
+	output.Transparent = &b
 	output.BGcolor = mpv.bgcolor
 
 	return output, nil

--- a/pkg/wms130/getmap_request_pv.go
+++ b/pkg/wms130/getmap_request_pv.go
@@ -99,11 +99,11 @@ func (mpv *getMapRequestParameterValue) buildOutput() (Output, Exceptions) {
 
 	h, err := strconv.Atoi(mpv.height)
 	if err != nil {
-		return output, InvalidParameterValue(HEIGHT, mpv.height).ToExceptions()
+		return output, InvalidParameterValue(mpv.height, HEIGHT).ToExceptions()
 	}
 	w, err := strconv.Atoi(mpv.width)
 	if err != nil {
-		return output, InvalidParameterValue(WIDTH, mpv.width).ToExceptions()
+		return output, InvalidParameterValue(mpv.width, WIDTH).ToExceptions()
 	}
 
 	output.Size = Size{Height: h, Width: w}

--- a/pkg/wms130/getmap_test.go
+++ b/pkg/wms130/getmap_test.go
@@ -302,6 +302,21 @@ func TestGetMapParseQueryParameters(t *testing.T) {
 					BGcolor:     sp(`0x7F7F7F`)},
 				Exceptions: sp("XML"),
 			}},
+		//REQUEST=GetMap&SERVICE=WMS&VERSION=1.3.0&LAYERS=Rivers,Roads,Houses&STYLES=CenterLine,CenterLine,Outline&CRS=EPSG:4326&BBOX=-180.0,-90.0,180.0,90.0&WIDTH=1024&HEIGHT=512&FORMAT=image/jpeg&TRANSPARENT=zzzz&EXCEPTIONS=XML
+		3: {query: map[string][]string{REQUEST: {getmap}, SERVICE: {Service}, VERSION: {Version},
+			LAYERS:      {`Rivers,Roads,Houses`},
+			STYLES:      {`CenterLine,CenterLine,Outline`},
+			"CRS":       {`EPSG:4326`},
+			BBOX:        {`-180.0,-90.0,180.0,90.0`},
+			WIDTH:       {`1024`},
+			HEIGHT:      {`512`},
+			FORMAT:      {`image/jpeg`},
+			TRANSPARENT: {`zzzz`},
+			EXCEPTIONS:  {`XML`},
+			BGCOLOR:     {`0x7F7F7F`},
+		},
+			exception: InvalidParameterValue(`zzzz`, TRANSPARENT),
+			},
 	}
 	for k, test := range tests {
 		var gm GetMapRequest


### PR DESCRIPTION
Currently invalid (i.e. non boolean) values are accepted for the 'transparent' parameter.