### PR TITLE
add (optional) supported language to supported languages

### DIFF
--- a/pkg/wcs201/capabilities.go
+++ b/pkg/wcs201/capabilities.go
@@ -61,6 +61,9 @@ type ExtendedCapabilities struct {
 			DefaultLanguage struct {
 				Language string `xml:"inspire_common:Language"`
 			} `xml:"inspire_common:DefaultLanguage"`
+			SupportedLanguage *[]struct {
+				Language string `xml:"inspire_common:Language" yaml:"language"`
+			} `xml:"inspire_common:SupportedLanguage" yaml:"supportedlanguage"`
 		} `xml:"inspire_common:SupportedLanguages"`
 		ResponseLanguage struct {
 			Language string `xml:"inspire_common:Language"`

--- a/pkg/wfs200/capabilities.go
+++ b/pkg/wfs200/capabilities.go
@@ -103,6 +103,9 @@ type ExtendedCapabilities struct {
 			DefaultLanguage struct {
 				Language string `xml:"inspire_common:Language" yaml:"language"`
 			} `xml:"inspire_common:DefaultLanguage" yaml:"defaultlanguage"`
+			SupportedLanguage *[]struct {
+				Language string `xml:"inspire_common:Language" yaml:"language"`
+			} `xml:"inspire_common:SupportedLanguage" yaml:"supportedlanguage"`
 		} `xml:"inspire_common:SupportedLanguages" yaml:"supportedlanguages"`
 		ResponseLanguage struct {
 			Language string `xml:"inspire_common:Language" yaml:"language"`

--- a/pkg/wms130/capabilities.go
+++ b/pkg/wms130/capabilities.go
@@ -260,6 +260,9 @@ type ExtendedCapabilities struct {
 		DefaultLanguage struct {
 			Language string `xml:"inspire_common:Language" yaml:"language"`
 		} `xml:"inspire_common:DefaultLanguage" yaml:"defaultlanguage"`
+		SupportedLanguage *[]struct {
+			Language string `xml:"inspire_common:Language" yaml:"language"`
+		} `xml:"inspire_common:SupportedLanguage" yaml:"supportedlanguage"`
 	} `xml:"inspire_common:SupportedLanguages" yaml:"supportedlanguages"`
 	ResponseLanguage struct {
 		Language string `xml:"inspire_common:Language" yaml:"language"`


### PR DESCRIPTION
Add optional supported languages to supportedLanguages element. Zie example 45 uit https://inspire.ec.europa.eu/documents/Network_Services/Technical_Guidance_Download_Services_v3.1.pdf
