### PR TITLE
removed Type from inspire/ext-cap/md-url

### DIFF
--- a/pkg/wcs201/capabilities.go
+++ b/pkg/wcs201/capabilities.go
@@ -53,7 +53,6 @@ type Post struct {
 type ExtendedCapabilities struct {
 	ExtendedCapabilities struct {
 		MetadataURL struct {
-			Type      string `xml:"xsi:type,attr"`
 			URL       string `xml:"inspire_common:URL"`
 			MediaType string `xml:"inspire_common:MediaType"`
 		} `xml:"inspire_common:MetadataUrl"`

--- a/pkg/wfs200/capabilities.go
+++ b/pkg/wfs200/capabilities.go
@@ -95,7 +95,6 @@ type ExtendedCapabilities struct {
 	ExtendedCapabilities struct {
 		Text        string `xml:",chardata"`
 		MetadataURL struct {
-			Type      string `xml:"xsi:type,attr" yaml:"type"`
 			URL       string `xml:"inspire_common:URL" yaml:"url"`
 			MediaType string `xml:"inspire_common:MediaType" yaml:"mediatype"`
 		} `xml:"inspire_common:MetadataUrl" yaml:"metadataurl"`

--- a/pkg/wms130/capabilities.go
+++ b/pkg/wms130/capabilities.go
@@ -252,7 +252,6 @@ type AuthorityURL struct {
 // ExtendedCapabilities containing the inspire extendedcapabilities, when available
 type ExtendedCapabilities struct {
 	MetadataURL struct {
-		Type      string `xml:"xsi:type,attr,omitempty" yaml:"type"`
 		URL       string `xml:"inspire_common:URL" yaml:"url"`
 		MediaType string `xml:"inspire_common:MediaType" yaml:"mediatype"`
 	} `xml:"inspire_common:MetadataUrl" yaml:"metadataurl"`


### PR DESCRIPTION
removed Type from inspire/ext-cap/md-url want niet in lijn met insp common xsd:
https://inspire.ec.europa.eu/schemas/common/1.0/common.xsd

Zie complexType: `resourceLocatorType`:

![afbeelding](https://user-images.githubusercontent.com/3216462/130963319-2c4c6aa4-b9e7-4ded-96f8-09df1f15dd60.png)

Technische gezien zouden meerdere mediatypes toegestaan zijn (vermoedelijk voor clients voor content-negotiation dmv request-headers).  Voor nu niet geimplementeerd. 