### PR TITLE
Fix wms layer sequence order.

### DIFF
--- a/pkg/wms130/capabilities.go
+++ b/pkg/wms130/capabilities.go
@@ -73,14 +73,17 @@ type Layer struct {
 	KeywordList             *Keywords                `xml:"KeywordList" yaml:"keywordlist"`
 	CRS                     []CRS                    `xml:"CRS" yaml:"crs"`
 	EXGeographicBoundingBox *EXGeographicBoundingBox `xml:"EX_GeographicBoundingBox" yaml:"exgeographicboundingbox"`
-	Dimension               []*Dimension             `xml:"Dimension" yaml:"dimension"`
 	BoundingBox             []*LayerBoundingBox      `xml:"BoundingBox" yaml:"boundingbox"`
-	AuthorityURL            *AuthorityURL            `xml:"AuthorityURL" yaml:"authorityurl"`
+	Dimension               []*Dimension             `xml:"Dimension" yaml:"dimension"`
 	Attribution             *Attribution             `xml:"Attribution,omitempty" yaml:"attribution"`
+	AuthorityURL            *AuthorityURL            `xml:"AuthorityURL" yaml:"authorityurl"`
 	Identifier              *Identifier              `xml:"Identifier" yaml:"identifier"`
-	FeatureListURL          *FeatureListURL          `xml:"FeatureListURL,omitempty" yaml:"featurelisturl"`
 	MetadataURL             []*MetadataURL           `xml:"MetadataURL" yaml:"metadataurl"`
+	DataURL                 *URL                     `xml:"DataURL,omitempty" yaml:"dataurl"`
+	FeatureListURL          *URL                     `xml:"FeatureListURL,omitempty" yaml:"featurelisturl"`
 	Style                   []*Style                 `xml:"Style" yaml:"style"`
+	MinScaleDenominator     *float64                 `xml:"MinScaleDenominator,omitempty" yaml:"minscaledenominator"`
+	MaxScaleDenominator     *float64                 `xml:"MaxScaleDenominator,omitempty" yaml:"maxscaledenominator"`
 	Layer                   []*Layer                 `xml:"Layer" yaml:"layer"`
 }
 
@@ -231,8 +234,8 @@ type Attribution struct {
 }
 
 // Identifier in struct for repeatability
-type FeatureListURL struct {
-	Format         string         `xml:"Format" yaml:"format"`
+type URL struct {
+	Format         *string        `xml:"Format" yaml:"format"`
 	OnlineResource OnlineResource `xml:"OnlineResource" yaml:"onlineresource"`
 }
 


### PR DESCRIPTION
# Omschrijving

Een omschrijving van wat je hebt toegevoegd/veranderd:

De layer definitie heeft een bepaalde volgorde. Dit zet de correcte volgorde. 
Zie ook de Layer definitie: http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd

https://dev.kadaster.nl/jira/browse/PDOK-13307

## Type verandering

(Verwijder de opties die niet relevant zijn.)

- Minor change (typo, formatting, version bump)
- Nieuwe feature
- Verbetering oude feature
- Bugfix
- Aanpassing van de configuratie

# Checklist:

- [X] Ik heb de code in deze PR zelf nogmaals nagekeken
- [X] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [x] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)