### PR TITLE
Legendurl is allowed to be empty.

### DIFF
--- a/pkg/wms130/capabilities.go
+++ b/pkg/wms130/capabilities.go
@@ -295,7 +295,7 @@ type Style struct {
 	Name      string `xml:"Name" yaml:"name"`
 	Title     string `xml:"Title" yaml:"title"`
 	Abstract  string `xml:"Abstract,omitempty" yaml:"abstract"`
-	LegendURL struct {
+	LegendURL *struct {
 		Width          int            `xml:"width,attr" yaml:"width"`
 		Height         int            `xml:"height,attr" yaml:"height"`
 		Format         string         `xml:"Format" yaml:"format"`


### PR DESCRIPTION
# Omschrijving

Een omschrijving van wat je hebt toegevoegd/veranderd:

We should allow legendurl to be empty (and should be ommitted if it does). This implements that change. 

See the http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd `minoccurs 0` for legendURL: 
![legendurlallowedempty](https://user-images.githubusercontent.com/10162961/133592247-ee070d5a-d3ad-4f83-a1a6-7cdfbb3c7b63.png)

## Type verandering

(Verwijder de opties die niet relevant zijn.)

- Bugfix

# Checklist:

- [X] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [X] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)